### PR TITLE
Changement du short_name mois 

### DIFF
--- a/src/components/utils/time_parser.rs
+++ b/src/components/utils/time_parser.rs
@@ -58,7 +58,7 @@ const UNITS: &[Unit] = &[
     },
     Unit {
         long_name: "mois",
-        short_name: "mois",
+        short_name: "m",
         value: MONTHS,
     },
     Unit {


### PR DESCRIPTION
Je trouve ça plus logique de mettre le raccourci de mois par m et non pas mois.